### PR TITLE
Resolve#1  Add logging feature needed for repetition of unit test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,4 +14,6 @@ repositories {
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile 'org.assertj:assertj-core:3.6.2'
+    testCompile 'org.slf4j:slf4j-api:1.7.5'
+    testCompile 'org.slf4j:slf4j-log4j12:1.7.5'
 }

--- a/src/test/java/com/naver/commerce_platform/junit/CalculatorTest.java
+++ b/src/test/java/com/naver/commerce_platform/junit/CalculatorTest.java
@@ -1,7 +1,12 @@
 package com.naver.commerce_platform.junit;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
+import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,12 +19,40 @@ public class CalculatorTest {
     static final Logger logger =
             LoggerFactory.getLogger(RepeatRunner.class);
 
+    @Rule
+    public final TestRule watchman = new TestWatcher() {
+        @Override
+        public Statement apply(Statement base, Description description) {
+            return super.apply(base, description);
+        }
+
+        @Override
+        protected void succeeded(Description description) {
+            logger.info("{} unit test succeeded.", description.getMethodName());
+        }
+
+        @Override
+        protected void failed(Throwable e, Description description) {
+            logger.error("{} unit test failed with {}.", description.getMethodName(), e);
+        }
+
+        @Override
+        protected void starting(Description description) {
+            super.starting(description);
+            logger.info("Run {}...", description);
+        }
+
+        @Override
+        protected void finished(Description description) {
+            super.finished(description);
+            logger.info("End {}...", description);
+        }
+    };
+
+
     @Test
     @Repeat(count = 5)
     public void testMyCode5Times() {
-        //Log
-        logger.info("Run testMyCode5Times...");
-
         //Arrange
         Calculator calculator = new Calculator();
         int x = 3;
@@ -35,9 +68,6 @@ public class CalculatorTest {
     @Test
     @Repeat(count = 10)
     public void testMyCode10Times() {
-        //Log
-        logger.info("Run testMyCode5Times...");
-
         //Arrange
         Calculator calculator = new Calculator();
         int x = 5;

--- a/src/test/java/com/naver/commerce_platform/junit/CalculatorTest.java
+++ b/src/test/java/com/naver/commerce_platform/junit/CalculatorTest.java
@@ -3,10 +3,7 @@ package com.naver.commerce_platform.junit;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
 import org.junit.runner.RunWith;
-import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,38 +14,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CalculatorTest {
 
     static final Logger logger =
-            LoggerFactory.getLogger(RepeatRunner.class);
+            LoggerFactory.getLogger(CalculatorTest.class);
 
     @Rule
-    public final TestRule watchman = new TestWatcher() {
-        @Override
-        public Statement apply(Statement base, Description description) {
-            return super.apply(base, description);
-        }
-
-        @Override
-        protected void succeeded(Description description) {
-            logger.info("{} unit test succeeded.", description.getMethodName());
-        }
-
-        @Override
-        protected void failed(Throwable e, Description description) {
-            logger.error("{} unit test failed with {}.", description.getMethodName(), e);
-        }
-
-        @Override
-        protected void starting(Description description) {
-            super.starting(description);
-            logger.info("Run {}...", description);
-        }
-
-        @Override
-        protected void finished(Description description) {
-            super.finished(description);
-            logger.info("End {}...", description);
-        }
-    };
-
+    public final TestRule watchman = new RepeatTestWatcher();
 
     @Test
     @Repeat(count = 5)

--- a/src/test/java/com/naver/commerce_platform/junit/CalculatorTest.java
+++ b/src/test/java/com/naver/commerce_platform/junit/CalculatorTest.java
@@ -2,6 +2,8 @@ package com.naver.commerce_platform.junit;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -9,9 +11,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(RepeatRunner.class)
 public class CalculatorTest {
 
+    static final Logger logger =
+            LoggerFactory.getLogger(RepeatRunner.class);
+
     @Test
     @Repeat(count = 5)
     public void testMyCode5Times() {
+        //Log
+        logger.info("Run testMyCode5Times...");
+
         //Arrange
         Calculator calculator = new Calculator();
         int x = 3;
@@ -27,6 +35,9 @@ public class CalculatorTest {
     @Test
     @Repeat(count = 10)
     public void testMyCode10Times() {
+        //Log
+        logger.info("Run testMyCode5Times...");
+
         //Arrange
         Calculator calculator = new Calculator();
         int x = 5;

--- a/src/test/java/com/naver/commerce_platform/junit/RepeatRunner.java
+++ b/src/test/java/com/naver/commerce_platform/junit/RepeatRunner.java
@@ -5,22 +5,22 @@ import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
-import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 public class RepeatRunner extends BlockJUnit4ClassRunner {
+    static final Logger logger =
+            LoggerFactory.getLogger(CalculatorTest.class);
     public RepeatRunner(Class<?> klass) throws InitializationError {
         super(klass);
     }
 
     @Override
-    protected Statement methodInvoker(FrameworkMethod method, Object test) {
-        System.out.println("invoking: " + method.getName());
-        return super.methodInvoker(method, test);
-    }
-
-    @Override
     protected void runChild(final FrameworkMethod method, RunNotifier notifier) {
-
+        logger.info("=============Repetition Test Start=============");
         Description description = describeChild(method);
         if (isIgnored(method)) {
             notifier.fireTestIgnored(description);
@@ -39,8 +39,35 @@ public class RepeatRunner extends BlockJUnit4ClassRunner {
                 runLeaf(methodBlock(method), description, notifier);
             }
         }
+
+        // RepeatTestInfo(totalCount, passCount, failCount)를 가져와 결과 요약 로그 작성
+        Class<?> cls = null;
+        try {
+            cls = Class.forName("com.naver.commerce_platform.junit."+"RepeatTestWatcher");
+            Object obj = cls.getDeclaredConstructor().newInstance();
+            Method getTotalCount = cls.getMethod("getTotalCount", String.class);
+            Method getPassCount = cls.getMethod("getPassCount", String.class);
+            Method getFailCount = cls.getMethod("getFailCount", String.class);
+            StringBuffer logMsg = new StringBuffer("");
+            logMsg.append("RepetitionTest: ")
+                    .append(method.getName())
+                    .append(", total_count: ")
+                    .append(getTotalCount.invoke(obj,method.getName()))
+                    .append(", pass_count: ")
+                    .append(getPassCount.invoke(obj,method.getName()))
+                    .append(", fail_count: ")
+                    .append(getFailCount.invoke(obj,method.getName()));
+            logger.info(String.valueOf(logMsg));
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        } catch (InstantiationException e) {
+            e.printStackTrace();
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
     }
-
-
-
 }

--- a/src/test/java/com/naver/commerce_platform/junit/RepeatTestInfo.java
+++ b/src/test/java/com/naver/commerce_platform/junit/RepeatTestInfo.java
@@ -1,0 +1,7 @@
+package com.naver.commerce_platform.junit;
+
+public class RepeatTestInfo {
+    public int totalCount = 0;
+    public int passCount = 0;
+    public int failCount = 0;
+}

--- a/src/test/java/com/naver/commerce_platform/junit/RepeatTestWatcher.java
+++ b/src/test/java/com/naver/commerce_platform/junit/RepeatTestWatcher.java
@@ -1,15 +1,28 @@
 package com.naver.commerce_platform.junit;
 
-import jdk.nashorn.internal.objects.annotations.Getter;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class RepeatTestWatcher extends TestWatcher {
     static final Logger logger =
             LoggerFactory.getLogger(CalculatorTest.class);
+    static Map<String, RepeatTestInfo> testResult = new HashMap<>();
+
+    public int getTotalCount(String methodName){
+        return this.testResult.get(methodName).totalCount;
+    }
+    public int getPassCount(String methodName){
+        return this.testResult.get(methodName).passCount;
+    }
+    public int getFailCount(String methodName){
+        return this.testResult.get(methodName).failCount;
+    }
 
     @Override
     public Statement apply(Statement base, Description description) {
@@ -19,11 +32,21 @@ public class RepeatTestWatcher extends TestWatcher {
     @Override
     protected void succeeded(Description description) {
         logger.info("{} unit test succeeded.", description.getMethodName());
+        RepeatTestInfo testInfo = testResult.get(description.getMethodName());
+        if (testInfo == null) {
+            testResult.put(description.getMethodName(),new RepeatTestInfo());
+        }
+        testResult.get(description.getMethodName()).passCount++;
     }
 
     @Override
     protected void failed(Throwable e, Description description) {
         logger.error("{} unit test failed with {}.", description.getMethodName(), e);
+        RepeatTestInfo testInfo = testResult.get(description.getMethodName());
+        if (testInfo == null) {
+            testResult.put(description.getMethodName(),new RepeatTestInfo());
+        }
+        testResult.get(description.getMethodName()).failCount++;
     }
 
     @Override
@@ -36,5 +59,10 @@ public class RepeatTestWatcher extends TestWatcher {
     protected void finished(Description description) {
         super.finished(description);
         logger.info("{} unit test finished...", description);
+        RepeatTestInfo testInfo = testResult.get(description.getMethodName());
+        if (testInfo == null) {
+            testResult.put(description.getMethodName(),new RepeatTestInfo());
+        }
+        testResult.get(description.getMethodName()).totalCount++;
     }
 }

--- a/src/test/java/com/naver/commerce_platform/junit/RepeatTestWatcher.java
+++ b/src/test/java/com/naver/commerce_platform/junit/RepeatTestWatcher.java
@@ -1,0 +1,40 @@
+package com.naver.commerce_platform.junit;
+
+import jdk.nashorn.internal.objects.annotations.Getter;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RepeatTestWatcher extends TestWatcher {
+    static final Logger logger =
+            LoggerFactory.getLogger(CalculatorTest.class);
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return super.apply(base, description);
+    }
+
+    @Override
+    protected void succeeded(Description description) {
+        logger.info("{} unit test succeeded.", description.getMethodName());
+    }
+
+    @Override
+    protected void failed(Throwable e, Description description) {
+        logger.error("{} unit test failed with {}.", description.getMethodName(), e);
+    }
+
+    @Override
+    protected void starting(Description description) {
+        super.starting(description);
+        logger.info("{} unit test starting...", description);
+    }
+
+    @Override
+    protected void finished(Description description) {
+        super.finished(description);
+        logger.info("{} unit test finished...", description);
+    }
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,8 +1,18 @@
 # Set root logger level to DEBUG, console and file
-log4j.rootLogger=DEBUG, console
+log4j.rootLogger=DEBUG, console, file
 # console is set to be a ConsoleAppender.
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.Target=System.out
 # console uses PatternLayout.
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.consoleAppender.layout.ConversionPattern=%d %-5p [%t] %-17c{2} (%13F:%L) %3x - %m%n
+
+# Direct log messages to a log file
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+# log file name & size
+log4j.appender.file.File=JUnit.log
+log4j.appender.file.MaxFileSize=10MB
+log4j.appender.file.MaxBackupIndex=10
+# file uses PatternLayout.
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d %-5p [%t] %-17c{2} (%13F:%L) %3x - %m%n

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Set root logger level to DEBUG, console and file
+log4j.rootLogger=DEBUG, console
+# console is set to be a ConsoleAppender.
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target=System.out
+# console uses PatternLayout.
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.consoleAppender.layout.ConversionPattern=%d %-5p [%t] %-17c{2} (%13F:%L) %3x - %m%n


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
* This resolves #1

## Details
<!-- Detailed description of the change/feature -->
- slf4j 로깅 프레임워크와 slf4j-log4j12 로깅 라이브러리를 이용해 로그 기능 추가
- 단위 테스트 상황에 맞는 로그 메시지 출력 (@override: succeeded, failed, starting, finished in JUnit's TestWatcher)
- 로그를 콘솔뿐만 아니라 파일에도 남길 수 있도록 기능 추가
- 단위 테스트별 반복 결과 요약 로그 구현
  - ex.) RepetitionTest: testMyCode5Times, total_count: 5, pass_count: 5, fail_count: 0
- 코드 리팩토링 (CalculatorTest에서 TestWatcher 코드 위치 분리)