### PR TITLE
Resolve#7 Fix counting logic of passCount

### DIFF
--- a/src/test/java/com/naver/commerce_platform/junit/CalculatorTest.java
+++ b/src/test/java/com/naver/commerce_platform/junit/CalculatorTest.java
@@ -17,6 +17,21 @@ public class CalculatorTest {
             LoggerFactory.getLogger(CalculatorTest.class);
 
     @Test
+    @Repeat(count = 5, testName = "random-assert-test")
+    public void testRandomAssert() {
+        //Arrange
+        Calculator calculator = new Calculator();
+        int x = (int)(2*Math.random());
+        int y = (int)(2*Math.random());
+
+        //Act
+        int result = calculator.add(x,y);
+
+        //Assert
+        assertThat(result).isEqualTo(1);
+    }
+
+    @Test
     @Repeat(count = 2, testName = "repeat-2")
     public void testMyCode2TimesWithName() {
         //Arrange

--- a/src/test/java/com/naver/commerce_platform/junit/RepeatRunListener.java
+++ b/src/test/java/com/naver/commerce_platform/junit/RepeatRunListener.java
@@ -14,8 +14,8 @@ public class RepeatRunListener extends RunListener {
 
     static final Logger logger =
             LoggerFactory.getLogger(CalculatorTest.class);
-    static Map<String, RepeatTestInfo> testResult = new HashMap<>();
-    private static final Description FAILED = Description.createTestDescription("failed", "failed");
+    private static Map<String, RepeatTestInfo> testResult = new HashMap<>();
+    private boolean failed = false;
 
     public int getTotalCount(String methodName){
         return this.testResult.get(methodName).totalCount;
@@ -44,7 +44,7 @@ public class RepeatRunListener extends RunListener {
 
     @Override
     public void testFinished(Description description) throws Exception {
-        if (!description.getChildren().contains(FAILED)) {
+        if (!this.failed) {
             // Process passed tests here...
             logger.info("{} unit test succeeded.", description.getMethodName());
             RepeatTestInfo testInfo = testResult.get(description.getMethodName());
@@ -55,6 +55,7 @@ public class RepeatRunListener extends RunListener {
         }
         logger.info("{} unit test finished...", description);
         testResult.get(description.getMethodName()).totalCount++;
+        this.failed=false;
     }
 
     @Override
@@ -65,7 +66,7 @@ public class RepeatRunListener extends RunListener {
             testResult.put(failure.getDescription().getMethodName(),new RepeatTestInfo());
         }
         testResult.get(failure.getDescription().getMethodName()).failCount++;
-        failure.getDescription().addChild(FAILED);
+        this.failed = true;
     }
 
     @Override


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
* This resolves #7 
## Details
<!-- Detailed description of the change/feature -->
* fail case일 때, description의 자식 객체로 추가한 FAILED description
객체를 각 테스트가 끝나고 다시 reset하는 로직이 없어 문제 발생
* testFinished 함수에서 받는 description으로 children을 clear해도 
fail case일 때 추가했던 FAILED description 객체가 사라지지 않음
* description에 fail case일때마다 FAILED description을 자식으로 추가하는
로직 대신 failed라는 flag 변수로 fail case를 체크하도록 로직 수정