### PR TITLE
Resolve#12 Apply test name to log & Handle invalid configured repeat-count

### DIFF
--- a/src/test/java/com/naver/commerce_platform/junit/CalculatorTest.java
+++ b/src/test/java/com/naver/commerce_platform/junit/CalculatorTest.java
@@ -16,7 +16,7 @@ public class CalculatorTest {
             LoggerFactory.getLogger(CalculatorTest.class);
 
     @Test
-    @Repeat(count = -1, testName = "invalid-repeat-count-test")
+    @Repeat(count = -1, testName = "invalid-repeat-count")
     public void testInvalidCountRepeat() {
         //Arrange
         Calculator calculator = new Calculator();
@@ -31,7 +31,7 @@ public class CalculatorTest {
     }
 
     @Test
-    @Repeat(count = 5, testName = "random-assert-test")
+    @Repeat(count = 5, testName = "random-assert")
     public void testRandomAssert() {
         //Arrange
         Calculator calculator = new Calculator();

--- a/src/test/java/com/naver/commerce_platform/junit/RepeatRunListener.java
+++ b/src/test/java/com/naver/commerce_platform/junit/RepeatRunListener.java
@@ -1,7 +1,6 @@
 package com.naver.commerce_platform.junit;
 
 import org.junit.runner.Description;
-import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 import org.slf4j.Logger;
@@ -17,63 +16,61 @@ public class RepeatRunListener extends RunListener {
     private static Map<String, RepeatTestInfo> testResult = new HashMap<>();
     /* fail flag */
     private boolean failed = false;
+    private String testName;
 
-    public int getTotalCount(String methodName){
-        return this.testResult.get(methodName).totalCount;
-    }
-    public int getPassCount(String methodName){
-        return this.testResult.get(methodName).passCount;
-    }
-    public int getFailCount(String methodName){
-        return this.testResult.get(methodName).failCount;
+    RepeatRunListener() {
+        super();
     }
 
-    @Override
-    public void testRunStarted(Description description) throws Exception {
-        System.out.println("Number of tests to execute: " + description.testCount());
+    public int getTotalCount(String testName){
+        return this.testResult.get(testName).totalCount;
     }
-
-    @Override
-    public void testRunFinished(Result result) throws Exception {
-        System.out.println("Number of tests executed: " + result.getRunCount());
+    public int getPassCount(String testName){
+        return this.testResult.get(testName).passCount;
+    }
+    public int getFailCount(String testName){
+        return this.testResult.get(testName).failCount;
+    }
+    public void setTestName(String testName) {
+        this.testName = testName;
     }
 
     @Override
     public void testStarted(Description description) throws Exception {
-        logger.info("{} unit test starting...", description);
+        logger.info("{} unit test starting...", testName);
     }
 
     @Override
     public void testFinished(Description description) throws Exception {
         if (!this.failed) {
             /* Process passed tests here */
-            logger.info("{} unit test succeeded.", description.getMethodName());
-            RepeatTestInfo testInfo = testResult.get(description.getMethodName());
+            logger.info("{} unit test succeeded.", testName);
+            RepeatTestInfo testInfo = testResult.get(testName);
             if (testInfo == null) {
-                testResult.put(description.getMethodName(),new RepeatTestInfo());
+                testResult.put(testName,new RepeatTestInfo());
             }
-            testResult.get(description.getMethodName()).passCount++;
+            testResult.get(testName).passCount++;
         }
-        logger.info("{} unit test finished...", description);
-        testResult.get(description.getMethodName()).totalCount++;
+        logger.info("{} unit test finished...", testName);
+        testResult.get(testName).totalCount++;
         this.failed=false;
     }
 
     @Override
     public void testFailure(Failure failure) throws Exception {
         /* Process failed tests here */
-        logger.error("{} unit test failed with {}.", failure.getDescription().getMethodName(), failure.getMessage());
-        RepeatTestInfo testInfo = testResult.get(failure.getDescription().getMethodName());
+        logger.error("{} unit test failed with {}.", testName, failure.getMessage());
+        RepeatTestInfo testInfo = testResult.get(testName);
         if (testInfo == null) {
-            testResult.put(failure.getDescription().getMethodName(),new RepeatTestInfo());
+            testResult.put(testName,new RepeatTestInfo());
         }
-        testResult.get(failure.getDescription().getMethodName()).failCount++;
+        testResult.get(testName).failCount++;
         this.failed = true;
     }
 
     @Override
     public void testIgnored(Description description) throws Exception {
         /* Process ignored tests here */
-        logger.info("Ignored: " + description.getMethodName());
+        logger.info("Ignored: " + testName);
     }
 }

--- a/src/test/java/com/naver/commerce_platform/junit/RepeatRunner.java
+++ b/src/test/java/com/naver/commerce_platform/junit/RepeatRunner.java
@@ -90,6 +90,8 @@ public class RepeatRunner extends BlockJUnit4ClassRunner {
 
             /* remove listener */
             notifier.removeListener(listener);
+
+            logger.info("=============Repetition Test Finished=============");
         } catch (ClassNotFoundException e) {
             e.printStackTrace();
         } catch (InstantiationException e) {

--- a/src/test/java/com/naver/commerce_platform/junit/RepeatRunner.java
+++ b/src/test/java/com/naver/commerce_platform/junit/RepeatRunner.java
@@ -43,7 +43,15 @@ public class RepeatRunner extends BlockJUnit4ClassRunner {
 
         /* if count < 1, throw IllegalArgumentException */
         if (count < 1) {
-            throw new IllegalArgumentException("count값은 1 이상이어야 합니다.");
+            try {
+                throw new IllegalArgumentException("count값은 1 이상이어야 합니다.");
+            } catch (IllegalArgumentException e) {
+                logger.error("Error:" +e.getMessage());
+                return;
+            } finally {
+                /* remove listener */
+                notifier.removeListener(listener);
+            }
         }
 
         /* set testName */

--- a/src/test/java/com/naver/commerce_platform/junit/RepeatRunner.java
+++ b/src/test/java/com/naver/commerce_platform/junit/RepeatRunner.java
@@ -1,7 +1,6 @@
 package com.naver.commerce_platform.junit;
 
 import org.junit.runner.Description;
-import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
@@ -23,7 +22,7 @@ public class RepeatRunner extends BlockJUnit4ClassRunner {
     protected void runChild(final FrameworkMethod method, RunNotifier notifier) {
         logger.info("=============Repetition Test Start=============");
         /* add listener */
-        RunListener listener = new RepeatRunListener();
+        RepeatRunListener listener = new RepeatRunListener();
         notifier.addListener(listener);
 
         /* handle ignore Annot. */
@@ -54,6 +53,7 @@ public class RepeatRunner extends BlockJUnit4ClassRunner {
         } else {
             testName = method.getAnnotation(Repeat.class).testName();
         }
+        listener.setTestName(testName);
 
         /* repeat unit test */
         for (int i =0; i<count; ++i) {
@@ -73,11 +73,11 @@ public class RepeatRunner extends BlockJUnit4ClassRunner {
             logMsg.append("RepetitionTest: ")
                     .append(testName)
                     .append(", total_count: ")
-                    .append(getTotalCount.invoke(obj,method.getName()))
+                    .append(getTotalCount.invoke(obj,testName))
                     .append(", pass_count: ")
-                    .append(getPassCount.invoke(obj,method.getName()))
+                    .append(getPassCount.invoke(obj,testName))
                     .append(", fail_count: ")
-                    .append(getFailCount.invoke(obj,method.getName()));
+                    .append(getFailCount.invoke(obj,testName));
             logger.info(String.valueOf(logMsg));
 
             /* remove listener */


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
* This resolves #12 
* Handle Repeat Annot.'s invaild configured repeat-count in all test run
## Details
<!-- Detailed description of the change/feature -->
* configured testName을 시작, 종료, 성공, 실패 상황 로그에 적용
* 각 unit test의 RepeatTestInfo를 저장하는 HashMap의 key값도 configured
testName으로 변경
* 전체 실행시, Repeat Annot.에 configured count가 1보다 작은 값이
들어가 illegal argument exception이 발생하는 unit test가 있어도
다른 unit test들은 실행이 될 수 있도록 수정